### PR TITLE
Fix compilation error in documented example

### DIFF
--- a/lib/Test2/Tools/QuickDB.pm
+++ b/lib/Test2/Tools/QuickDB.pm
@@ -111,7 +111,7 @@ This is a test library build around DBIx::QuickDB.
 
     skipall_unless_can_db(driver => 'PostgreSQL');
 
-    my $db = get_db(driver => 'PostgreSQL', load_sql => 't/schema/postgresql.sql'});
+    my $db = get_db({driver => 'PostgreSQL', load_sql => 't/schema/postgresql.sql'});
 
     ...
 


### PR DESCRIPTION
A missing opening `{` causes the following compilation error:

```
Unmatched right curly bracket at t/001-basics.t line 6, at end of line
syntax error at t/001-basics.t line 6, near "'t/schema/postgresql.sql'}"
t/001-basics.t had compilation errors.
```

This small change corrects the documentation by adding the missing opening `{`.